### PR TITLE
Fixes bug where leak_info was not being set in evaluate_final_action.py

### DIFF
--- a/evaluation/evaluate_final_action.py
+++ b/evaluation/evaluate_final_action.py
@@ -300,7 +300,9 @@ def main():
                 secret_judgment = [(s, False) for s in secrets[actions.iloc[i]['name']]]
             else:
                 for s, o in zip(secrets[actions.iloc[i]['name']], output):
-                    secret_judgment.append((s, parse_leakage_judgment(o[0].text)))
+                    parsed_leakage_judgment = parse_leakage_judgment(o[0].text)
+                    secret_judgment.append((s, parsed_leakage_judgment))
+                    leak_info |= parsed_leakage_judgment
             name_to_result[actions.iloc[i]['name']] = {'leak_info': leak_info, 'secret_judgment': secret_judgment}
         elif args.step == 'helpfulness':
             if len(output) == 0:


### PR DESCRIPTION
First of all, thank you very much for the interesting paper, dataset and well written code.

I am currently reproducing the results and noticed this bug after having leakage rate of 0 even though secrets were being leaked. The bug was that in the judge_leakage step, leak_info was never being set to true in case of a leakage of any secret, and thus leakage rate was always 0.

This pull request fixes this bug.

Thank you again for your work.
Kind regards